### PR TITLE
fix:  xDel special semmantics patch

### DIFF
--- a/src/vdbeapi.c
+++ b/src/vdbeapi.c
@@ -1538,9 +1538,10 @@ int sqlite3_bind_blob(sqlite3_stmt *pStmt, int i, const void *zData, int nData,
 #ifdef __sqlite_unmodified_upstream
   return bindText(pStmt, i, zData, nData, xDel, 0);
 #else
-  // xDel is a custom deallocator, due to our IT architecture it can't be
-  // provided from other modules.
-  return bindText(pStmt, i, zData, nData, free, 0);
+  // xDel is a custom deallocator and if it is not SQLITE_STATIC
+  // due to our IT architecture it can't be provided from other modules.
+  return bindText(pStmt, i, zData, nData,
+    (xDel==SQLITE_STATIC || xDel==SQLITE_TRANSIENT)?xDel:free, 0);
 #endif
 }
 int sqlite3_bind_blob64(sqlite3_stmt *pStmt, int i, const void *zData,
@@ -1598,9 +1599,10 @@ int sqlite3_bind_text(sqlite3_stmt *pStmt, int i, const char *zData, int nData,
 #ifdef __sqlite_unmodified_upstream
   return bindText(pStmt, i, zData, nData, xDel, SQLITE_UTF8);
 #else
-  // xDel is a custom deallocator, due to our IT architecture it can't be
-  // provided from other modules.
-  return bindText(pStmt, i, zData, nData, free, SQLITE_UTF8);
+  // xDel is a custom deallocator and if it is not SQLITE_STATIC
+  // due to our IT architecture it can't be provided from other modules.
+  return bindText(pStmt, i, zData, nData,
+    (xDel==SQLITE_STATIC || xDel==SQLITE_TRANSIENT)?xDel:free, SQLITE_UTF8);
 #endif
 }
 int sqlite3_bind_text64(sqlite3_stmt *pStmt, int i, const char *zData,


### PR DESCRIPTION
    Sqlite has a number of special custom memory deallocators, namely SQLITE_STATIC and SQLITE_TRANSIENT. Sqlite calls noop freeing memory with the special deallocators.
    Sqlite virtual tables, e.g. FTS5 implicitly creates aux tables. There are number of SQLITE_STATIC allocated empty lines or 0 size blobs that were previously freed with free. This free op spoils sqlite virtual table state  and renders VT unusable.
Fixes #6 